### PR TITLE
Support for Windows and Python 3.

### DIFF
--- a/src/OrderedStage.py
+++ b/src/OrderedStage.py
@@ -3,13 +3,22 @@
 from .Stage import Stage
 from .OrderedWorker import OrderedWorker
 
+__all__ = ['OrderedStage']
+
+
+class _Worker(OrderedWorker):
+    def __init__(self, task_fn):
+        super(_Worker, self).__init__()
+        self.task_fn = task_fn
+
+    def doTask(self, task):
+        return self.task_fn(task)
+
+
 class OrderedStage(Stage):
     """A specialized :class:`~mpipe.Stage`, 
     internally creating :class:`~mpipe.OrderedWorker` objects."""
     def __init__(self, target, size=1, disable_result=False):
         """Constructor takes a function implementing 
         :meth:`OrderedWorker.doTask`."""
-        class wclass(OrderedWorker):
-            def doTask(self, task):
-                return target(task)
-        super(OrderedStage, self).__init__(wclass, size, disable_result)
+        super(OrderedStage, self).__init__(_Worker, size, disable_result, task_fn=target)

--- a/src/UnorderedStage.py
+++ b/src/UnorderedStage.py
@@ -4,14 +4,24 @@ from .Stage import Stage
 from .UnorderedWorker import UnorderedWorker
 from .TubeQ import TubeQ
 
+__all__ = ['UnorderedStage']
+
+
+class _Worker(UnorderedWorker):
+    def __init__(self, task_fn):
+        super(_Worker, self).__init__()
+        self.task_fn = task_fn
+
+    def doTask(self, task):
+        return self.task_fn(task)
+
+
 class UnorderedStage(Stage):
     """A specialized :class:`~mpipe.Stage`, 
     internally creating :class:`~mpipe.UnorderedWorker` objects."""
     def __init__(self, target, size=1, disable_result=False, max_backlog=None):
         """Constructor takes a function implementing
         :meth:`UnorderedWorker.doTask`."""
-        class wclass(UnorderedWorker):
-            def doTask(self, task):
-                return target(task)
-        super(UnorderedStage, self).__init__(wclass, size, disable_result,
-                                             input_tube=TubeQ(maxsize=max_backlog) if max_backlog else None)
+        super(UnorderedStage, self).__init__(_Worker, size, disable_result,
+                                             input_tube=TubeQ(maxsize=max_backlog) if max_backlog else None,
+                                             task_fn=target)

--- a/test/backlog.py
+++ b/test/backlog.py
@@ -1,7 +1,6 @@
 from sys import stdout
 from threading import Thread
 from time import sleep
-
 from mpipe.Pipeline import Pipeline
 from mpipe.UnorderedStage import UnorderedStage
 
@@ -10,10 +9,12 @@ def write(value):
     stdout.write(str(value))
     stdout.flush()
 
+
 def inc(x):
     sleep(0.1)
     write('+')
     return x+1
+
 
 def dec(x):
     sleep(0.2)
@@ -21,26 +22,29 @@ def dec(x):
     return x-1
 
 
-stage1 = UnorderedStage(inc, 3, max_backlog=3)
-stage2 = UnorderedStage(dec, 1, max_backlog=1)
-stage1.link(stage2)
-pipeline = Pipeline(stage1)
-
-
-def print_results():
+def print_results(pipeline):
     for result in pipeline.results():
         write(result)
 
-print_thread = Thread(target=print_results)
-print_thread.start()
+
+def main():
+    stage1 = UnorderedStage(inc, 3, max_backlog=3)
+    stage2 = UnorderedStage(dec, 1, max_backlog=1)
+    stage1.link(stage2)
+    pipeline = Pipeline(stage1)
+
+    print_thread = Thread(target=print_results, args=(pipeline,))
+    print_thread.start()
+
+    for i in range(10):
+        sleep(0.01)
+        pipeline.put(i)
+        write('i')
+
+    pipeline.put(None)
+    print_thread.join()
+    write('\n')
 
 
-for i in range(10):
-    sleep(0.01)
-    pipeline.put(i)
-    write('i')
-
-pipeline.put(None)
-print_thread.join()
-write('\n')
-
+if __name__ == '__main__':
+    main()

--- a/test/bottleneck1.py
+++ b/test/bottleneck1.py
@@ -1,14 +1,21 @@
 import time
-from mpipe import OrderedStage, Pipeline
+from mpipe import (OrderedStage, Pipeline)
+
 
 def echo(value):
     print(value)
     time.sleep(0.013)
     return value
 
-pipe = Pipeline(OrderedStage(echo))
-for number in range(12):
-    pipe.put(number)
-    time.sleep(0.010)
 
-pipe.put(None)
+def main():
+    pipe = Pipeline(OrderedStage(echo))
+    for number in range(12):
+        pipe.put(number)
+        time.sleep(0.010)
+
+    pipe.put(None)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/bottleneck2.py
+++ b/test/bottleneck2.py
@@ -1,14 +1,21 @@
 import time
-from mpipe import OrderedStage, Pipeline
+from mpipe import (OrderedStage, Pipeline)
+
 
 def echo(value):
     print(value)
     time.sleep(0.013)
     return value
 
-pipe = Pipeline(OrderedStage(echo, 2))
-for number in range(12):
-    pipe.put(number)
-    time.sleep(0.010)
 
-pipe.put(None)
+def main():
+    pipe = Pipeline(OrderedStage(echo, 2))
+    for number in range(12):
+        pipe.put(number)
+        time.sleep(0.010)
+
+    pipe.put(None)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/bottleneck3.py
+++ b/test/bottleneck3.py
@@ -1,15 +1,22 @@
 import time
-from mpipe import OrderedStage, FilterStage, Pipeline
+from mpipe import (OrderedStage, FilterStage, Pipeline)
+
 
 def echo(value):
     print(value)
     time.sleep(0.013)
     return value
 
-stage = FilterStage((OrderedStage(echo),), max_tasks=2)
-pipe = Pipeline(stage)
-for number in range(12):
-    pipe.put(number)
-    time.sleep(0.010)
 
-pipe.put(None)
+def main():
+    stage = FilterStage((OrderedStage(echo),), max_tasks=2)
+    pipe = Pipeline(stage)
+    for number in range(12):
+        pipe.put(number)
+        time.sleep(0.010)
+
+    pipe.put(None)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/buylow.py
+++ b/test/buylow.py
@@ -1,10 +1,11 @@
 from collections import deque
 import numpy as np
-from mpipe import OrderedWorker, Stage, OrderedStage, Pipeline
+from mpipe import (OrderedWorker, Stage, OrderedStage, Pipeline)
 
 last10 = deque()
 junk = 'http://ws.cdyne.com/delayedstockquote/delayedstockquote.asmx/GetQuote?StockSymbol=fac&LicenseKey=0'
 j = 'http://www.google.com/ig/api?stock=AAPL'
+
 
 class Accumulator(OrderedWorker):
     def doTask(self, price):
@@ -15,18 +16,25 @@ class Accumulator(OrderedWorker):
         if len(last10) > 10:
             last10.popleft()
 
+
 def echo(value):
     print('value = {0}'.format(value))
 
-stage1 = Stage(Accumulator)
-stage2 = OrderedStage(echo, 50)
-stage1.link(stage2)
-pipe = Pipeline(stage1)
 
-SIZE = 1000
-prices = np.linspace(0, np.pi*10, SIZE)
-prices = np.sin(prices) + 1
-for price in prices:
-    pipe.put(price)
+def main():
+    stage1 = Stage(Accumulator)
+    stage2 = OrderedStage(echo, 50)
+    stage1.link(stage2)
+    pipe = Pipeline(stage1)
 
-pipe.put(None)
+    size = 1000
+    prices = np.linspace(0, np.pi*10, size)
+    prices = np.sin(prices) + 1
+    for price in prices:
+        pipe.put(price)
+
+    pipe.put(None)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/chain.py
+++ b/test/chain.py
@@ -1,22 +1,31 @@
-from mpipe import OrderedStage, Pipeline
+from mpipe import (OrderedStage, Pipeline)
+
 
 def increment(value):
     return value + 1
 
+
 def double(value):
     return value * 2
+
 
 def echo(value):
     print(value)
 
-stage1 = OrderedStage(increment)
-stage2 = OrderedStage(double)
-stage3 = OrderedStage(echo)
-stage1.link(stage2)
-stage2.link(stage3)
-pipe = Pipeline(stage1)
 
-for number in range(10):
-    pipe.put(number)
+def main():
+    stage1 = OrderedStage(increment)
+    stage2 = OrderedStage(double)
+    stage3 = OrderedStage(echo)
+    stage1.link(stage2)
+    stage2.link(stage3)
+    pipe = Pipeline(stage1)
 
-pipe.put(None)
+    for number in range(10):
+        pipe.put(number)
+
+    pipe.put(None)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/clog.py
+++ b/test/clog.py
@@ -1,16 +1,25 @@
-import sys
-from mpipe import UnorderedStage, Pipeline
+# import sys
+from builtins import range
+from mpipe import (UnorderedStage, Pipeline)
+
 
 def increment(value):
     return value + 1
 
-stage = UnorderedStage(increment)
-pipe = Pipeline(stage)
 
-for task in xrange(sys.maxint):
-    pipe.put(task)
+def main():
+    stage = UnorderedStage(increment)
+    pipe = Pipeline(stage)
 
-pipe.put(None)
+    # for task in range(sys.maxint if sys.version_info.major <= 2 else sys.maxsize):
+    for task in range(10000):
+        pipe.put(task)
 
-for result in pipe.results():
-    print(result)
+    pipe.put(None)
+
+    for result in pipe.results():
+        print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/count_nullops.py
+++ b/test/count_nullops.py
@@ -1,14 +1,18 @@
 from datetime import datetime
+from builtins import range
 
-def getNumNullops(duration, max_sample=1.0):
+
+def get_num_null_ops(duration, max_sample=1.0):
     """Return number of do-nothing loop iterations."""
     for amount in [2**x for x in range(100)]:  # 1,2,4,8,...
         begin = datetime.now()
-        for ii in xrange(amount): pass
+        for ii in range(amount):
+            pass
         elapsed = (datetime.now() - begin).total_seconds()
         if elapsed > max_sample:
             break
     return int(amount/elapsed*duration)
 
+
 if __name__ == '__main__':
-    print(getNumNullops(1.0))
+    print(get_num_null_ops(1.0))

--- a/test/disable_result0.py
+++ b/test/disable_result0.py
@@ -1,14 +1,20 @@
-from mpipe import OrderedStage, Pipeline
+from mpipe import (OrderedStage, Pipeline)
+
 
 def yes(value):
     return value
 
-pipe = Pipeline(OrderedStage(yes, disable_result=True))
 
-for number in range(10):
-    pipe.put(number)
+def main():
+    pipe = Pipeline(OrderedStage(yes, disable_result=True))
 
-pipe.put(None)
+    for number in range(10):
+        pipe.put(number)
+    pipe.put(None)
 
-for result in pipe.results():
-    print(result)
+    for result in pipe.results():
+        print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/disable_result1.py
+++ b/test/disable_result1.py
@@ -1,18 +1,24 @@
-from mpipe import OrderedStage, Pipeline
+from mpipe import (OrderedStage, Pipeline)
+
 
 def yes(value):
     return value
 
-stage = OrderedStage(yes, 4, disable_result=True)
-pipe = Pipeline(stage)
 
-for number in range(10):
-    pipe.put(number)
+def main():
+    stage = OrderedStage(yes, 4, disable_result=True)
+    pipe = Pipeline(stage)
 
-pipe.put(None)
+    for number in range(10):
+        pipe.put(number)
+    pipe.put(None)
 
-count = 0
-for result in pipe.results():
-    count += 1
+    count = 0
+    for _ in pipe.results():
+        count += 1
 
-print(count)
+    print(count)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/disable_result2.py
+++ b/test/disable_result2.py
@@ -1,19 +1,25 @@
-from mpipe import OrderedWorker, Stage, Pipeline
+from mpipe import (OrderedWorker, Stage, Pipeline)
+
 
 class Yes(OrderedWorker):
     def doTask(self, value):
         return value
 
-stage = Stage(Yes, 4, disable_result=True)
-pipe = Pipeline(stage)
 
-for number in range(10):
-    pipe.put(number)
+def main():
+    stage = Stage(Yes, 4, disable_result=True)
+    pipe = Pipeline(stage)
 
-pipe.put(None)
+    for number in range(10):
+        pipe.put(number)
+    pipe.put(None)
 
-count = 0
-for result in pipe.results():
-    count += 1
+    count = 0
+    for _ in pipe.results():
+        count += 1
 
-print(count)
+    print(count)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/disable_result3.py
+++ b/test/disable_result3.py
@@ -1,19 +1,25 @@
-from mpipe import UnorderedWorker, Stage, Pipeline
+from mpipe import (UnorderedWorker, Stage, Pipeline)
+
 
 class Yes(UnorderedWorker):
     def doTask(self, value):
         return value
 
-stage = Stage(Yes, 4, disable_result=True)
-pipe = Pipeline(stage)
 
-for number in range(10):
-    pipe.put(number)
+def main():
+    stage = Stage(Yes, 4, disable_result=True)
+    pipe = Pipeline(stage)
 
-pipe.put(None)
+    for number in range(10):
+        pipe.put(number)
+    pipe.put(None)
 
-count = 0
-for result in pipe.results():
-    count += 1
+    count = 0
+    for _ in pipe.results():
+        count += 1
 
-print(count)
+    print(count)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/do_stop_task1.py
+++ b/test/do_stop_task1.py
@@ -1,13 +1,19 @@
-from mpipe import Stage, OrderedWorker, Pipeline
+from mpipe import (Stage, OrderedWorker, Pipeline)
+
 
 class Echo(OrderedWorker):
     def doTask(self, value):
         print(value)
 
-stage = Stage(Echo, do_stop_task=True)
-pipe = Pipeline(stage)
 
-for number in range(10):
-    pipe.put(number)
+def main():
+    stage = Stage(Echo, do_stop_task=True)
+    pipe = Pipeline(stage)
 
-pipe.put(None)
+    for number in range(10):
+        pipe.put(number)
+    pipe.put(None)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/do_stop_task2.py
+++ b/test/do_stop_task2.py
@@ -1,17 +1,24 @@
-from mpipe import Stage, OrderedWorker, FilterStage, Pipeline
+from mpipe import (Stage, OrderedWorker, FilterStage, Pipeline)
+
 
 class Echo(OrderedWorker):
     def doTask(self, value):
         print(value)
 
-s1 = Stage(Echo, do_stop_task=True)
-s2 = FilterStage(
-    (s1,), 
-    max_tasks=999,
-    do_stop_task=True,
-    )
-pipe = Pipeline(s2)
-for number in range(10):
-    pipe.put(number)
 
-pipe.put(None)
+def main():
+    s1 = Stage(Echo, do_stop_task=True)
+    s2 = FilterStage(
+        (s1,),
+        max_tasks=999,
+        do_stop_task=True,
+        )
+    pipe = Pipeline(s2)
+
+    for number in range(10):
+        pipe.put(number)
+    pipe.put(None)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/drano.py
+++ b/test/drano.py
@@ -1,21 +1,33 @@
-import sys
-from mpipe import UnorderedStage, Pipeline
+# import sys
+from builtins import range
+from mpipe import (UnorderedStage, Pipeline)
+
 
 def increment(value):
     return value + 1
 
-stage = UnorderedStage(increment)
-pipe = Pipeline(stage)
 
-def pull(value):
-    for result in pipe.results():
-        print(result)
+class Pull:
+    def __init__(self, pipe):
+        self.pipe = pipe
 
-pipe2 = Pipeline(UnorderedStage(pull))
-pipe2.put(True)
+    def __call__(self, value):
+        for result in self.pipe.results():
+            print(result)
 
-for task in xrange(sys.maxint):
-    pipe.put(task)
 
-pipe.put(None)
-pipe2.put(None)
+def main():
+    pipe = Pipeline(UnorderedStage(increment))
+    pipe2 = Pipeline(UnorderedStage(Pull(pipe)))
+    pipe2.put(True)
+
+    # for task in range(sys.maxint):
+    for task in range(10000):
+        pipe.put(task)
+    pipe.put(None)
+
+    pipe2.put(None)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/filter1.py
+++ b/test/filter1.py
@@ -1,30 +1,40 @@
 import time
-from mpipe import OrderedStage, FilterStage, Pipeline
+from mpipe import (OrderedStage, FilterStage, Pipeline, OrderedWorker, Stage)
 
-def passthru(value):
+
+def pass_thru(value):
     time.sleep(0.013)
     return value
 
-s1 = FilterStage(
-    (OrderedStage(passthru),), 
-    max_tasks=1,
-    )
-p1 = Pipeline(s1)
 
-def pull(task):
-    for task, result in p1.results():
-        if result:
-            print('{0} {1}'.format(task, result[0]))
+class Pull(object):
+    def __init__(self, pipe):
+        self.pipe = pipe
 
-p2 = Pipeline(OrderedStage(pull))
-p2.put(True)
+    def __call__(self, task):
+        for task, result in self.pipe.results():
+            print('{0} {1}'.format(task, result))
+        #    # if result:
+        #    #     print('{0} {1}'.format(task, result[0]))
 
 
-for number in range(10):
-    p1.put(number)
-    time.sleep(0.010)
+def main():
+    s1 = FilterStage(
+        (OrderedStage(pass_thru),),
+        max_tasks=1,
+        )
+    p1 = Pipeline(s1)
 
-p1.put(None)
-p2.put(None)
+    p2 = Pipeline(OrderedStage(Pull(p1)))
+    p2.put(True)
+
+    for number in range(10):
+        p1.put(number)
+        time.sleep(0.010)
+
+    p1.put(None)
+    p2.put(None)
 
 
+if __name__ == '__main__':
+    main()

--- a/test/filter11.py
+++ b/test/filter11.py
@@ -1,30 +1,39 @@
 import time
-from mpipe import OrderedStage, FilterStage, Pipeline
+from mpipe import (OrderedStage, FilterStage, Pipeline)
 
-def passthru(value):
+
+def pass_thru(value):
     time.sleep(0.013)
     return value
 
-s1 = FilterStage(
-    (OrderedStage(passthru),), 
-    max_tasks=2,
-    )
-p1 = Pipeline(s1)
 
-def pull(task):
-    for task, result in p1.results():
-        if result:
-            print('{0} {1}'.format(task, result[0]))
+class Pull:
+    def __init__(self, pipe):
+        self.pipe = pipe
 
-p2 = Pipeline(OrderedStage(pull))
-p2.put(True)
+    def __call__(self, task):
+        for task, result in self.pipe.results():
+            if result:
+                print('{0} {1}'.format(task, result[0]))
 
 
-for number in range(10):
-    p1.put(number)
-    time.sleep(0.010)
+def main():
+    s1 = FilterStage(
+        (OrderedStage(pass_thru),),
+        max_tasks=2,
+        )
+    p1 = Pipeline(s1)
 
-p1.put(None)
-p2.put(None)
+    p2 = Pipeline(OrderedStage(Pull(p1)))
+    p2.put(True)
+
+    for number in range(10):
+        p1.put(number)
+        time.sleep(0.010)
+
+    p1.put(None)
+    p2.put(None)
 
 
+if __name__ == '__main__':
+    main()

--- a/test/filter2.py
+++ b/test/filter2.py
@@ -1,31 +1,36 @@
 import time
 from mpipe import OrderedStage, FilterStage, Pipeline
 
-def passthru(value):
+
+def pass_thru(value):
     time.sleep(0.013)
     return value
 
-s1 = FilterStage(
-    (OrderedStage(passthru),), 
-    max_tasks=1,
-    cache_results=True,
-    )
-p1 = Pipeline(s1)
 
-def pull(task):
-    for task, result in p1.results():
-        if result:
-            print('{0} {1}'.format(task, result[0]))
+class Pull:
+    def __init__(self, pipe):
+        self.pipe = pipe
 
-p2 = Pipeline(OrderedStage(pull))
-p2.put(True)
+    def __call__(self, task):
+        for task, result in self.pipe.results():
+            if result:
+                print('{0} {1}'.format(task, result[0]))
 
 
-for number in range(10):
-    p1.put(number)
-    time.sleep(0.010)
+def main():
+    s1 = FilterStage(
+        (OrderedStage(pass_thru),),
+        max_tasks=1,
+        cache_results=True,
+        )
+    p1 = Pipeline(s1)
 
-p1.put(None)
-p2.put(None)
+    p2 = Pipeline(OrderedStage(Pull(p1)))
+    p2.put(True)
 
+    for number in range(10):
+        p1.put(number)
+        time.sleep(0.010)
 
+    p1.put(None)
+    p2.put(None)

--- a/test/filter21.py
+++ b/test/filter21.py
@@ -1,31 +1,41 @@
 import time
-from mpipe import OrderedStage, FilterStage, Pipeline
+from mpipe import (OrderedStage, FilterStage, Pipeline)
 
-def passthru(value):
+
+def pass_thru(value):
     time.sleep(0.013)
     return value
 
-s1 = FilterStage(
-    (OrderedStage(passthru),), 
-    max_tasks=2,
-    cache_results=True,
-    )
-p1 = Pipeline(s1)
 
-def pull(task):
-    for task, result in p1.results():
-        if result:
-            print('{0} {1}'.format(task, result[0]))
+class Pull:
+    def __init__(self, pipe):
+        self.pipe = pipe
 
-p2 = Pipeline(OrderedStage(pull))
-p2.put(True)
+    def __call__(self, task):
+        for task, result in self.pipe.results():
+            if result:
+                print('{0} {1}'.format(task, result[0]))
 
 
-for number in range(10):
-    p1.put(number)
-    time.sleep(0.010)
+def main():
+    s1 = FilterStage(
+        (OrderedStage(pass_thru),),
+        max_tasks=2,
+        cache_results=True,
+        )
+    p1 = Pipeline(s1)
 
-p1.put(None)
-p2.put(None)
+    p2 = Pipeline(OrderedStage(Pull(p1)))
+    p2.put(True)
 
 
+    for number in range(10):
+        p1.put(number)
+        time.sleep(0.010)
+
+    p1.put(None)
+    p2.put(None)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/filter3.py
+++ b/test/filter3.py
@@ -1,31 +1,40 @@
 import time
-from mpipe import OrderedStage, FilterStage, Pipeline
+from mpipe import (OrderedStage, FilterStage, Pipeline)
 
-def passthru(value):
+
+def pass_thru(value):
     time.sleep(0.013)
     return value
 
-s1 = FilterStage(
-    (OrderedStage(passthru),), 
-    max_tasks=1,
-    drop_results=True,
-    )
-p1 = Pipeline(s1)
 
-def pull(task):
-    for result in p1.results():
-        if result:
-            print(result)
+class Pull:
+    def __init__(self, pipe):
+        self.pipe = pipe
 
-p2 = Pipeline(OrderedStage(pull))
-p2.put(True)
+    def __call__(self, task):
+        for result in self.pipe.results():
+            if result:
+                print(result)
 
 
-for number in range(10):
-    p1.put(number)
-    time.sleep(0.010)
+def main():
+    s1 = FilterStage(
+        (OrderedStage(pass_thru),),
+        max_tasks=1,
+        drop_results=True,
+        )
+    p1 = Pipeline(s1)
 
-p1.put(None)
-p2.put(None)
+    p2 = Pipeline(OrderedStage(Pull(p1)))
+    p2.put(True)
+
+    for number in range(10):
+        p1.put(number)
+        time.sleep(0.010)
+
+    p1.put(None)
+    p2.put(None)
 
 
+if __name__ == '__main__':
+    main()

--- a/test/fork.py
+++ b/test/fork.py
@@ -1,29 +1,38 @@
-from mpipe import OrderedWorker, Stage, Pipeline
+from mpipe import (OrderedWorker, Stage, Pipeline)
+
 
 class Incrementor(OrderedWorker):
     def doTask(self, value):
         return value + 1
 
+
 class Doubler(OrderedWorker):
     def doTask(self, value):
         return value * 2
+
 
 class Printer(OrderedWorker):
     def doTask(self, value):
         print(value)
 
-stage1 = Stage(Incrementor)
-stage2 = Stage(Doubler)
-stage3 = Stage(Printer)
-stage4 = Stage(Printer)
 
-stage1.link(stage2)
-stage1.link(stage3)
-stage2.link(stage4)
+def main():
+    stage1 = Stage(Incrementor)
+    stage2 = Stage(Doubler)
+    stage3 = Stage(Printer)
+    stage4 = Stage(Printer)
 
-pipe = Pipeline(stage1)
+    stage1.link(stage2)
+    stage1.link(stage3)
+    stage2.link(stage4)
 
-for number in range(10):
-    pipe.put(number)
+    pipe = Pipeline(stage1)
 
-pipe.put(None)
+    for number in range(10):
+        pipe.put(number)
+
+    pipe.put(None)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/helloworld.py
+++ b/test/helloworld.py
@@ -1,12 +1,19 @@
 import mpipe
 
+
 def echo(value):
     print(value)
 
-stage = mpipe.OrderedStage(echo)
-pipe = mpipe.Pipeline(stage)
 
-for val in (0, 1, 2, 3):
-    pipe.put(val)
+def main():
+    stage = mpipe.OrderedStage(echo)
+    pipe = mpipe.Pipeline(stage)
 
-pipe.put(None)  # Stop the pipeline.
+    for val in (0, 1, 2, 3):
+        pipe.put(val)
+
+    pipe.put(None)  # Stop the pipeline.
+
+
+if __name__ == '__main__':
+    main()

--- a/test/link1.py
+++ b/test/link1.py
@@ -1,19 +1,26 @@
-from mpipe import OrderedStage as OStage, Pipeline
+from mpipe import (OrderedStage as OStage, Pipeline)
+
 
 def magnify(value):
     return value*10
 
-p1 = Pipeline(
-    OStage(magnify).link(
+
+def main():
+    p1 = Pipeline(
         OStage(magnify).link(
             OStage(magnify).link(
-                OStage(magnify)
+                OStage(magnify).link(
+                    OStage(magnify)
+                    )
                 )
             )
         )
-    )
-for val in list(range(10)) + [None]:
-    p1.put(val)
+    for val in list(range(10)) + [None]:
+        p1.put(val)
 
-for result in p1.results():
-    print(result)
+    for result in p1.results():
+        print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/link_ou.py
+++ b/test/link_ou.py
@@ -1,19 +1,27 @@
-from mpipe import OrderedStage, UnorderedStage, Pipeline
+from mpipe import (OrderedStage, UnorderedStage, Pipeline)
+
 
 def increment(value):
     return value + 1
 
+
 def double(value):
     return value * 2
 
-stage1 = OrderedStage(increment, 3)
-stage2 = UnorderedStage(double, 3)
-stage1.link(stage2)
-pipe = Pipeline(stage1)
 
-for number in range(10):
-    pipe.put(number)
-pipe.put(None)
+def main():
+    stage1 = OrderedStage(increment, 3)
+    stage2 = UnorderedStage(double, 3)
+    stage1.link(stage2)
+    pipe = Pipeline(stage1)
 
-for result in pipe.results():
-    print(result)
+    for number in range(10):
+        pipe.put(number)
+    pipe.put(None)
+
+    for result in pipe.results():
+        print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/link_uo.py
+++ b/test/link_uo.py
@@ -1,19 +1,27 @@
-from mpipe import OrderedStage, UnorderedStage, Pipeline
+from mpipe import (OrderedStage, UnorderedStage, Pipeline)
+
 
 def increment(value):
     return value + 1
 
+
 def double(value):
     return value * 2
 
-stage1 = UnorderedStage(increment, 3)
-stage2 = OrderedStage(double, 3)
-stage1.link(stage2)
-pipe = Pipeline(stage1)
 
-for number in range(10):
-    pipe.put(number)
-pipe.put(None)
+def main():
+    stage1 = UnorderedStage(increment, 3)
+    stage2 = OrderedStage(double, 3)
+    stage1.link(stage2)
+    pipe = Pipeline(stage1)
 
-for result in pipe.results():
-    print(result)
+    for number in range(10):
+        pipe.put(number)
+    pipe.put(None)
+
+    for result in pipe.results():
+        print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/multiwork.py
+++ b/test/multiwork.py
@@ -1,13 +1,22 @@
 import sys
 import mpipe
+from builtins import range
 
-def forloop(amount):
-    for ii in xrange(amount): pass
 
-stage = mpipe.UnorderedStage(forloop, 2)
-pipe = mpipe.Pipeline(stage)
+def for_loop(amount):
+    for ii in range(amount):
+        pass
 
-for foobar in range(5): 
-    pipe.put(int(sys.argv[1]))
 
-pipe.put(None)
+def main():
+    stage = mpipe.UnorderedStage(for_loop, 2)
+    pipe = mpipe.Pipeline(stage)
+
+    for foobar in range(5):
+        pipe.put(int(sys.argv[1]) if len(sys.argv) >= 2 else 10)
+
+    pipe.put(None)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/pipeout.py
+++ b/test/pipeout.py
@@ -1,20 +1,28 @@
-from mpipe import OrderedStage, Pipeline
+from mpipe import (OrderedStage, Pipeline)
+
 
 def increment(value):
     return value + 1
 
+
 def double(value):
     return value * 2
 
-stage1 = OrderedStage(increment)
-stage2 = OrderedStage(double)
-stage1.link(stage2)
-pipe = Pipeline(stage1)
 
-for number in range(10):
-    pipe.put(number)
+def main():
+    stage1 = OrderedStage(increment)
+    stage2 = OrderedStage(double)
+    stage1.link(stage2)
+    pipe = Pipeline(stage1)
 
-pipe.put(None)
+    for number in range(10):
+        pipe.put(number)
 
-for result in pipe.results():
-    print(result)
+    pipe.put(None)
+
+    for result in pipe.results():
+        print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/stackoverflow1.py
+++ b/test/stackoverflow1.py
@@ -1,20 +1,28 @@
 """Solution for http://stackoverflow.com/questions/8277715"""
 
-from mpipe import OrderedStage, Pipeline
+from mpipe import (OrderedStage, Pipeline)
+
 
 def f2(value):
     return value * 2
 
+
 def f3(value):
     print(value)
 
-s1 = OrderedStage(f2, size=2)
-s2 = OrderedStage(f3)
-s1.link(s2)
-p = Pipeline(s1)
 
-def f1():
-    for task in [1,2,3,4,5,None]:
-        p.put(task)
+def main():
+    s1 = OrderedStage(f2, size=2)
+    s2 = OrderedStage(f3)
+    s1.link(s2)
+    p = Pipeline(s1)
 
-f1()
+    def f1():
+        for task in [1, 2, 3, 4, 5, None]:
+            p.put(task)
+
+    f1()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/tiny.py
+++ b/test/tiny.py
@@ -1,19 +1,27 @@
-from mpipe import OrderedStage, Pipeline
+from mpipe import (OrderedStage, Pipeline)
+
 
 def increment(value):
     return value + 1
 
+
 def double(value):
     return value * 2
 
-stage1 = OrderedStage(increment, 3)
-stage2 = OrderedStage(double, 3)
-pipe = Pipeline(stage1.link(stage2))
 
-for number in range(10):
-    pipe.put(number)
+def main():
+    stage1 = OrderedStage(increment, 3)
+    stage2 = OrderedStage(double, 3)
+    pipe = Pipeline(stage1.link(stage2))
 
-pipe.put(None)
+    for number in range(10):
+        pipe.put(number)
 
-for result in pipe.results():
-    print(result)
+    pipe.put(None)
+
+    for result in pipe.results():
+        print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/tiny2.py
+++ b/test/tiny2.py
@@ -1,22 +1,29 @@
 import mpipe
 
+
 class Incrementor(mpipe.UnorderedWorker):
     def doTask(self, value):
         return value + 1
-    
+
+
 class Doubler(mpipe.UnorderedWorker):
     def doTask(self, value):
         return value * 2
-    
-stage1 = mpipe.Stage(Incrementor, 3)
-stage2 = mpipe.Stage(Doubler, 3)
-stage1.link(stage2)
-pipe = mpipe.Pipeline(stage1)
 
-for number in range(10):
-    pipe.put(number)
-pipe.put(None)
 
-for result in pipe.results():
-    print(result)
+def main():
+    stage1 = mpipe.Stage(Incrementor, 3)
+    stage2 = mpipe.Stage(Doubler, 3)
+    stage1.link(stage2)
+    pipe = mpipe.Pipeline(stage1)
 
+    for number in range(10):
+        pipe.put(number)
+    pipe.put(None)
+
+    for result in pipe.results():
+        print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/tiny3.py
+++ b/test/tiny3.py
@@ -1,23 +1,31 @@
 import mpipe
 
+
 class Incrementor(mpipe.OrderedWorker):
     def doTask(self, value):
         result = value + 1
         self.putResult(result)
+
 
 class Doubler(mpipe.OrderedWorker):
     def doTask(self, value):
         result = value * 2
         self.putResult(result)
 
-stage1 = mpipe.Stage(Incrementor, 13)
-stage2 = mpipe.Stage(Doubler, 13)
-stage1.link(stage2)
-pipe = mpipe.Pipeline(stage1)
 
-for number in range(10):
-    pipe.put(number)
-pipe.put(None)
+def main():
+    stage1 = mpipe.Stage(Incrementor, 13)
+    stage2 = mpipe.Stage(Doubler, 13)
+    stage1.link(stage2)
+    pipe = mpipe.Pipeline(stage1)
 
-for result in pipe.results():
-    print(result)
+    for number in range(10):
+        pipe.put(number)
+    pipe.put(None)
+
+    for result in pipe.results():
+        print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/tiny4.py
+++ b/test/tiny4.py
@@ -1,23 +1,31 @@
 import mpipe
 
+
 class Incrementor(mpipe.UnorderedWorker):
     def doTask(self, value):
         result = value + 1
         self.putResult(result)
+
 
 class Doubler(mpipe.UnorderedWorker):
     def doTask(self, value):
         result = value * 2
         self.putResult(result)
 
-stage1 = mpipe.Stage(Incrementor, 3)
-stage2 = mpipe.Stage(Doubler, 3)
-stage1.link(stage2)
-pipe = mpipe.Pipeline(stage1)
 
-for number in range(10):
-    pipe.put(number)
-pipe.put(None)
+def main():
+    stage1 = mpipe.Stage(Incrementor, 3)
+    stage2 = mpipe.Stage(Doubler, 3)
+    stage1.link(stage2)
+    pipe = mpipe.Pipeline(stage1)
 
-for result in pipe.results():
-    print(result)
+    for number in range(10):
+        pipe.put(number)
+    pipe.put(None)
+
+    for result in pipe.results():
+        print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/unordered.py
+++ b/test/unordered.py
@@ -1,20 +1,28 @@
-from mpipe import UnorderedStage, Pipeline
+from mpipe import (UnorderedStage, Pipeline)
+
 
 def increment(value):
     return value + 1
 
+
 def double(value):
     return value * 2
 
-stage1 = UnorderedStage(increment, 2)
-stage2 = UnorderedStage(double, 2)
-stage1.link(stage2)
-pipe = Pipeline(stage1)
 
-for number in range(10):
-    pipe.put(number)
+def main():
+    stage1 = UnorderedStage(increment, 2)
+    stage2 = UnorderedStage(double, 2)
+    stage1.link(stage2)
+    pipe = Pipeline(stage1)
 
-pipe.put(None)
+    for number in range(10):
+        pipe.put(number)
 
-for result in pipe.results():
-    print(result)
+    pipe.put(None)
+
+    for result in pipe.results():
+        print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/workparam.py
+++ b/test/workparam.py
@@ -1,18 +1,27 @@
-from mpipe import OrderedWorker, Stage, Pipeline
+from mpipe import (OrderedWorker, Stage, Pipeline)
+
 
 class Adder(OrderedWorker):
     def __init__(self, number):
+        super(Adder, self).__init__()
         self.number = number
+
     def doTask(self, value):
         return value + self.number
 
-stage1 = Stage(Adder, 1, number=5)
-pipe = Pipeline(stage1)
 
-for number in range(10):
-    pipe.put(number)
+def main():
+    stage1 = Stage(Adder, 1, number=5)
+    pipe = Pipeline(stage1)
 
-pipe.put(None)
+    for number in range(10):
+        pipe.put(number)
 
-for result in pipe.results():
-    print(result)
+    pipe.put(None)
+
+    for result in pipe.results():
+        print(result)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Hi!

This PR is supposed to fix the issue [#12](https://github.com/vmlaker/mpipe/issues/12) that adds support for Windows and Python 3:

- Refactoring [OrderedStage](https://github.com/sergey-serebryakov/mpipe/blob/bugfix/windows-support/src/OrderedStage.py) and [UnorderedStage](https://github.com/sergey-serebryakov/mpipe/blob/bugfix/windows-support/src/UnorderedStage.py) classes. The classes with `wclass` (worker class) names have been renamed to `_Worker` and have been moved to the package level. This makes them pickable in windows world.
- Updating all tests. Mostly, adding `main` functions.
- Commenting `sys.maxint` in two test since it's not available in Python 3 (in Python 3 there's `sys.maxsize`) variable. In two tests that used this variable the number of tasks is set to 10,000.

I tested with Ubuntu / Windows 10 and Python 3.8.

Several things that yet need to be fixed:
- One test fails in Ubuntu ([filter1.py](https://github.com/sergey-serebryakov/mpipe/blob/bugfix/windows-support/test/filter1.py))
- Two tests fail in Windows ([backlog.py](https://github.com/sergey-serebryakov/mpipe/blob/bugfix/windows-support/test/backlog.py), [filter1.py](https://github.com/sergey-serebryakov/mpipe/blob/bugfix/windows-support/test/filter1.py))
- I can't fully understand the logic behind these two tests - [clog.py](https://github.com/sergey-serebryakov/mpipe/blob/bugfix/windows-support/test/clog.py) and [drano.py](https://github.com/sergey-serebryakov/mpipe/blob/bugfix/windows-support/test/drano.py). The use `sys.maxint` tasks which is not available in Python 3 (it's proabably `sys.maxsize`). How are these tests supposed to work? I just changed the number of tasks to be 10,000.
